### PR TITLE
pull files in batch for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All other configuration is done via environment variables:
 | `ELB_INGESTOR_SEARCH_PREFIX`       | Prefix ("folder") under which to look for log files    | "logs/"                        |
 | `ELB_INGESTOR_WORKING_PREFIX`      | Prefix to put logs being ingested into                 | "logs-working/"                |
 | `ELB_INGESTOR_DONE_PREFIX`         | Prefix to put log files that have been ingested into   | "logs-done/"                   |
-| `ELB_INGESTOR_START_QUEUE_SIZE`    | Number of log files to pull into queue at startup      | 5                              |
+| `ELB_INGESTOR_FILE_BATCH_SIZE`     | Number of log files to pull at a time for processing   | 5                              |
 | `ELB_INGESTOR_LISTEN_HOST`         | Hostname or IP address to listen on for healthchecks   | "localhost"                    |
 | `ELB_INGESTOR_LISTEN_PORT`         | Port to listen on for healthchecks                     | 13131                          |
 | `ELB_INGESTOR_ELASTICSEARCH_HOSTS` | Comma-separated list of hosts (`host1:443,host2:9123`) | No default                     |

--- a/elb_log_ingestor/elb_log_parse.py
+++ b/elb_log_ingestor/elb_log_parse.py
@@ -161,8 +161,6 @@ class LogParser:
                 self.parse_alb_logs(name, lines)
                 self.file_out_queue.put(name)
                 self.stats.increment_files_processed()
-            else:
-                threading.sleep(30)
 
     def parse_alb_logs(self, name, lines: typing.List[str]) -> None:
         """

--- a/elb_log_ingestor/main.py
+++ b/elb_log_ingestor/main.py
@@ -35,7 +35,7 @@ def start_server():
     unprocessed_prefix = os.environ.get("ELB_INGESTOR_SEARCH_PREFIX", "logs/")
     processing_prefix = os.environ.get("ELB_INGESTOR_WORKING_PREFIX", "logs-working/")
     processed_prefix = os.environ.get("ELB_INGESTOR_DONE_PREFIX", "logs-done/")
-    start_queue_size = int(os.environ.get("ELB_INGESTOR_START_QUEUE_SIZE", 5))
+    file_batch_size = int(os.environ.get("ELB_INGESTOR_FILE_BATCH_SIZE", 5))
     index_pattern = os.environ.get("ELB_INDEX_PATTERN", "logs-platform-%Y.%m.%d")
     fetcher = elb_log_fetcher.S3LogFetcher(
         bucket,
@@ -44,7 +44,7 @@ def start_server():
         processed_prefix=processed_prefix,
         to_do=logs_to_be_processed,
         done=logs_processed,
-        start_queue_size=start_queue_size,
+        file_batch_size=file_batch_size
     )
 
     parser = elb_log_parse.LogParser(


### PR DESCRIPTION
The speedup here is _insane_, which makes me think this doesn't work how I think it does. 

The original goal was to reduce the overhead of fetching new files from AWS by doing it in batches, and also to reduce the amount of time wasted sleeping waiting for logs.

the old code processed ~4k lines in ~24 hours. 
the new code processed ~6k lines in ~8 minutes